### PR TITLE
BUGFIX: Fix missing repository in pom.xml to enable local builds

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,6 +24,13 @@
 
     <modelVersion>4.0.0</modelVersion>
 
+    <repositories>
+        <repository>
+            <id>jenkins</id>
+            <url>http://repo.jenkins-ci.org/releases/</url>
+        </repository>
+    </repositories>
+
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>


### PR DESCRIPTION
Before this commit, it was impossible to build this plugin locally
due to missing source repository.