### PR TITLE
Update dependencies for Java 11

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,4 @@
 #!/usr/bin/env groovy
 
 /* `buildPlugin` step provided by: https://github.com/jenkins-infra/pipeline-library */
-buildPlugin()
+buildPlugin(configurations: buildPlugin.recommendedConfigurations())

--- a/pom.xml
+++ b/pom.xml
@@ -89,15 +89,15 @@
 
     <properties>
         <java.level>8</java.level>
-        <jenkins.version>2.107.2</jenkins.version>
+        <jenkins.version>2.164.1</jenkins.version>
         <!-- define all plugin versions -->
         <configuration-as-code.version>1.35</configuration-as-code.version>
         <gson.version>2.8.2</gson.version>
         <gearman.version>0.6</gearman.version>
         <hamcrest.version>2.2</hamcrest.version>
-        <mockito.version>2.15.0</mockito.version>
-        <powermock.version>2.0.0-beta.5</powermock.version>
-        <objenesis.version>2.6</objenesis.version>
+        <mockito.version>2.28.2</mockito.version>
+        <powermock.version>2.0.7</powermock.version>
+        <objenesis.version>3.0.1</objenesis.version>
         <jenkins-maven-plugin>3.1</jenkins-maven-plugin>
         <jenkins-workflow-job-plugin>2.17</jenkins-workflow-job-plugin>
         <jenkins-workflow-cps-plugin>2.45</jenkins-workflow-cps-plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -29,6 +29,11 @@
             <id>jenkins</id>
             <url>http://repo.jenkins-ci.org/releases/</url>
         </repository>
+        <repository>
+            <id>wikimedia.releases</id>
+            <name>Wikimedia Release Repository</name>
+            <url>https://archiva.wikimedia.org/repository/releases</url>
+        </repository>
     </repositories>
     <pluginRepositories>
         <pluginRepository>
@@ -93,7 +98,7 @@
         <!-- define all plugin versions -->
         <configuration-as-code.version>1.35</configuration-as-code.version>
         <gson.version>2.8.2</gson.version>
-        <gearman.version>0.6</gearman.version>
+        <gearman.version>0.9</gearman.version>
         <hamcrest.version>2.2</hamcrest.version>
         <mockito.version>2.28.2</mockito.version>
         <powermock.version>2.0.7</powermock.version>
@@ -102,6 +107,7 @@
         <jenkins-workflow-job-plugin>2.17</jenkins-workflow-job-plugin>
         <jenkins-workflow-cps-plugin>2.45</jenkins-workflow-cps-plugin>
         <jenkins-structs-plugin>1.14</jenkins-structs-plugin>
+        <slf4j-api>1.7.30</slf4j-api>
         <maven.javadoc.skip>true</maven.javadoc.skip>
         <findbugs.failOnError>false</findbugs.failOnError>
     </properties>
@@ -126,9 +132,20 @@
             <version>${hamcrest.version}</version>
         </dependency>
         <dependency>
-            <groupId>org.gearman</groupId>
+            <groupId>org.wikimedia.gearman</groupId>
             <artifactId>gearman-java</artifactId>
             <version>${gearman.version}</version>
+            <exclusions>
+                <!--
+                    Jenkins brings slf4j-over-slf4j which does the opposite
+                    of slf4j-log4j12.
+                    https://www.slf4j.org/codes.html#log4jDelegationLoop
+                -->
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-log4j12</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>com.google.code.gson</groupId>
@@ -166,6 +183,26 @@
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>structs</artifactId>
             <version>${jenkins-structs-plugin}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>${slf4j-api}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>jcl-over-slf4j</artifactId>
+            <version>${slf4j-api}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>log4j-over-slf4j</artifactId>
+            <version>${slf4j-api}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-jdk14</artifactId>
+            <version>${slf4j-api}</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>

--- a/src/test/java/hudson/plugins/gearman/GearmanPluginConfigTest.java
+++ b/src/test/java/hudson/plugins/gearman/GearmanPluginConfigTest.java
@@ -28,6 +28,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
@@ -37,6 +38,7 @@ import org.powermock.modules.junit4.PowerMockRunner;
  * @author Khai Do
  */
 @RunWith(PowerMockRunner.class)
+@PowerMockIgnore({"javax.xml.*"})
 @PrepareForTest(Jenkins.class)
 public class GearmanPluginConfigTest {
 


### PR DESCRIPTION
Bump Jenkins to 2.164.1 for Java 11 version (I have found doc
mentionning 2.138 and some other requiring 2.164).

Update some dependencies for Java 11 support:

* Mockito 2.15.0..2.28.2 to latest 2.x release. The release notes show a
  lot of Java 11 related changes.
* Powermock 2.0.0-beta.5..2.0.7
* objenesis 2.6..3.0.1 which is also a dependency of Powermock

Add a PowerMockIgnore annotation for `javax.xml.*` in
GearmanPluginConfigTest to prevent the following kind of error:

  java.lang.ExceptionInInitializerError
  ..
  Caused by: java.lang.IllegalAccessError:
    class javax.xml.datatype.FactoryFinder (in unnamed module @0x371ff923)
    cannot access class jdk.xml.internal.SecuritySupport (in module java.xml)
    because module java.xml does not export jdk.xml.internal to unnamed
    module @0x371ff923

Ran tests with:

  rm -fR target
  JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64 mvn clean package

  rm -fR target
  JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64 mvn clean package

Bug: https://phabricator.wikimedia.org/T271683