### PR TITLE
Upgrade gearman-java 0.9..0.10

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -91,7 +91,7 @@
         <!-- define all plugin versions -->
         <configuration-as-code.version>1.35</configuration-as-code.version>
         <gson.version>2.8.2</gson.version>
-        <gearman.version>0.9</gearman.version>
+        <gearman.version>0.10</gearman.version>
         <hamcrest.version>2.2</hamcrest.version>
         <mockito.version>2.28.2</mockito.version>
         <powermock.version>2.0.7</powermock.version>


### PR DESCRIPTION
Addresses ByteBuffer compatibility when running under JDK 8:
https://gerrit.wikimedia.org/r/c/integration/gearman-java/+/666004

Bug: https://phabricator.wikimedia.org/T271683#6847594