### PR TITLE
Introduce bom and build against 2.235.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -87,37 +87,48 @@
 
     <properties>
         <java.level>8</java.level>
-        <jenkins.version>2.164.1</jenkins.version>
-        <!-- define all plugin versions -->
-        <configuration-as-code.version>1.35</configuration-as-code.version>
+        <jenkins.version>2.235.1</jenkins.version>
         <gson.version>2.8.2</gson.version>
         <gearman.version>0.10</gearman.version>
         <hamcrest.version>2.2</hamcrest.version>
         <mockito.version>2.28.2</mockito.version>
         <powermock.version>2.0.7</powermock.version>
         <objenesis.version>3.0.1</objenesis.version>
-        <jenkins-maven-plugin>3.1</jenkins-maven-plugin>
-        <jenkins-workflow-job-plugin>2.17</jenkins-workflow-job-plugin>
-        <jenkins-workflow-cps-plugin>2.45</jenkins-workflow-cps-plugin>
-        <jenkins-structs-plugin>1.14</jenkins-structs-plugin>
+        <jenkins-maven-plugin>3.8</jenkins-maven-plugin>
         <slf4j-api>1.7.30</slf4j-api>
         <maven.javadoc.skip>true</maven.javadoc.skip>
         <findbugs.failOnError>false</findbugs.failOnError>
     </properties>
 
 
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>io.jenkins.tools.bom</groupId>
+                <artifactId>bom-2.235.x</artifactId>
+                <version>25</version>
+                <scope>import</scope>
+                <type>pom</type>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
         <dependency>
             <groupId>io.jenkins</groupId>
             <artifactId>configuration-as-code</artifactId>
-            <version>${configuration-as-code.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>io.jenkins.configuration-as-code</groupId>
             <artifactId>test-harness</artifactId>
-            <version>${configuration-as-code.version}</version>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.jenkins-ci.main</groupId>
+                    <artifactId>jenkins-test-harness</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.hamcrest</groupId>
@@ -156,26 +167,18 @@
             <version>${jenkins-maven-plugin}</version>
             <exclusions>
                 <exclusion>
-                    <groupId>org.apache.maven.wagon</groupId>
-                    <artifactId>wagon-ftp</artifactId>
+                    <groupId>org.apache.commons</groupId>
+                    <artifactId>commons-lang3</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-job</artifactId>
-            <version>${jenkins-workflow-job-plugin}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.jenkins-ci.plugins</groupId>
-                    <artifactId>structs</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>structs</artifactId>
-            <version>${jenkins-structs-plugin}</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
@@ -200,13 +203,6 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-cps</artifactId>
-            <version>${jenkins-workflow-cps-plugin}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.jenkins-ci.plugins</groupId>
-                    <artifactId>structs</artifactId>
-                </exclusion>
-            </exclusions>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/src/test/java/hudson/plugins/gearman/GearmanPluginConfigTest.java
+++ b/src/test/java/hudson/plugins/gearman/GearmanPluginConfigTest.java
@@ -50,6 +50,7 @@ public class GearmanPluginConfigTest {
     public void setUp() {
         Jenkins jenkins = mock(Jenkins.class);
         PowerMockito.mockStatic(Jenkins.class);
+        when(Jenkins.get()).thenReturn(jenkins);
         when(Jenkins.getInstance()).thenReturn(jenkins);
         gpc = new GearmanPluginConfig();
     }


### PR DESCRIPTION
* Point to Jenkins 2.235.1 as recommendended from the plugin development
  documentation
* Use bom instead of trying to keep track of plugins
* Update maven-plugin to 3.8 for Java 11 support

In GearmanPluginConfigTest, mock Jenkins.get() after changes have been
made in Jenkins 2.180 which replaced call to Jenkins.getInstance().