### PR TITLE
Use modern ACL.as2() to run as SYSTEM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -87,7 +87,7 @@
 
     <properties>
         <java.level>8</java.level>
-        <jenkins.version>2.235.1</jenkins.version>
+        <jenkins.version>2.277.1</jenkins.version>
         <gson.version>2.8.2</gson.version>
         <gearman.version>0.10</gearman.version>
         <hamcrest.version>2.2</hamcrest.version>

--- a/src/main/java/hudson/plugins/gearman/GearmanPluginUtil.java
+++ b/src/main/java/hudson/plugins/gearman/GearmanPluginUtil.java
@@ -21,14 +21,13 @@ package hudson.plugins.gearman;
 import hudson.model.Computer;
 import hudson.model.Run;
 import hudson.security.ACL;
+import hudson.security.ACLContext;
 
 import java.io.IOException;
 import java.util.Optional;
 
 import jenkins.model.Jenkins;
 
-import org.acegisecurity.context.SecurityContextHolder;
-import org.acegisecurity.context.SecurityContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -75,8 +74,7 @@ public class GearmanPluginUtil {
      */
     public static Run<?,?> findBuild(String jobName, int buildNumber) {
 
-        SecurityContext oldContext = ACL.impersonate(ACL.SYSTEM);
-        try {
+        try (ACLContext ctx = ACL.as2(ACL.SYSTEM2)) {
             Optional<GearmanProject> aproject = GearmanProject.getAllItems()
                     .stream()
                     .filter( (GearmanProject item) -> item.getJob().getName().equalsIgnoreCase(jobName))
@@ -89,8 +87,6 @@ public class GearmanPluginUtil {
                 }
             }
             return null;
-        } finally {
-            SecurityContextHolder.setContext(oldContext);
         }
     }
 
@@ -103,11 +99,8 @@ public class GearmanPluginUtil {
      *      New build description
      */
     public static void setBuildDescription(Run build, String description) throws IOException {
-        SecurityContext oldContext = ACL.impersonate(ACL.SYSTEM);
-        try {
+        try (ACLContext ctx = ACL.as2(ACL.SYSTEM2)) {
             build.setDescription(description);
-        } finally {
-            SecurityContextHolder.setContext(oldContext);
         }
     }
 }


### PR DESCRIPTION
Sometime when invoking the stop function, the management worker thread
would die:

  A thread (Gearman worker 172.17.0.1_manager/563) died unexpectedly due
  to an uncaught exception, this may leave your Jenkins in a bad way and
  is usually indicative of a bug in the code.
  java.lang.StackOverflowError
    at org.acegisecurity.context.SecurityContext$1.getAuthentication(SecurityContext.java:46)
    at org.acegisecurity.context.SecurityContext$2.getAuthentication(SecurityContext.java:60)
    at org.acegisecurity.context.SecurityContext$1.getAuthentication(SecurityContext.java:46)

That started happening after we upgraded to the LTS 2.277 series and I
thus highly suspect it is related to JEP-227:
https://github.com/jenkinsci/jep/blob/master/jep/227/README.adoc

Replace impersonate calls with the modern ACL.as2() introduced in
Jenkins 2.266.

Bump Jenkins requirement to current LTS series (2.277).

Reference: https://phabricator.wikimedia.org/T281737