### PR TITLE
Jenkins 2.139

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 Overview
 ========
-This plugin uses Gearman to support multiple Jenkins masters.
+This plugin uses Gearman to support multiple Jenkins controllers.
 
 More informations can be found at https://plugins.jenkins.io/gearman-plugin/
 
@@ -8,8 +8,8 @@ History
 =======
 
 The plugin has been originally written by Khai Do (@zaro0508) for the OpenStack
-CI infrastructure. They needed a way to scale Jenkins to multiple masters and
-went with the Gearman protocol since some were familiar with it. OpenStack
+CI infrastructure. They needed a way to scale Jenkins to multiple controllers
+and went with the Gearman protocol since some were familiar with it. OpenStack
 eventually replaced Jenkins with Ansible and the plugin.
 
 The Gooddata company forked it and notably added support for Jenkins Pipeline

--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>3.57</version>
+        <version>4.19</version>
         <relativePath />
     </parent>
 
@@ -87,15 +87,15 @@
 
     <properties>
         <java.level>8</java.level>
-        <jenkins.version>2.277.1</jenkins.version>
+        <jenkins.version>2.319.1</jenkins.version>
         <gson.version>2.8.2</gson.version>
         <gearman.version>0.10</gearman.version>
         <hamcrest.version>2.2</hamcrest.version>
         <mockito.version>2.28.2</mockito.version>
         <powermock.version>2.0.7</powermock.version>
         <objenesis.version>3.0.1</objenesis.version>
-        <jenkins-maven-plugin>3.8</jenkins-maven-plugin>
-        <slf4j-api>1.7.30</slf4j-api>
+        <jenkins-maven-plugin>3.15</jenkins-maven-plugin>
+        <slf4j-api>1.7.32</slf4j-api>
         <maven.javadoc.skip>true</maven.javadoc.skip>
         <findbugs.failOnError>false</findbugs.failOnError>
     </properties>
@@ -105,8 +105,8 @@
         <dependencies>
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
-                <artifactId>bom-2.235.x</artifactId>
-                <version>25</version>
+                <artifactId>bom-2.319.x</artifactId>
+                <version>1013.vf8058992a042</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>

--- a/src/main/java/hudson/plugins/gearman/ComputerListenerImpl.java
+++ b/src/main/java/hudson/plugins/gearman/ComputerListenerImpl.java
@@ -76,7 +76,7 @@ public class ComputerListenerImpl extends ComputerListener {
     @Override
     public void onOnline(Computer c, TaskListener listener) throws IOException,
             InterruptedException {
-        // gets called when master goes into online state
+        // gets called when built-in node goes into online state
         // gets called when existing slave re-connects
         // gets called when new slave goes into online state
         logger.debug("---- " + ComputerListenerImpl.class.getName() + ":"
@@ -101,7 +101,7 @@ public class ComputerListenerImpl extends ComputerListener {
 
     @Override
     public void onTemporarilyOffline(Computer c, OfflineCause cause) {
-        // fired when master or slave goes into temporary offline state
+        // fired when built-in node or slave goes into temporary offline state
         logger.debug("---- " + ComputerListenerImpl.class.getName() + ":"
                 + " onTemporarilyOffline computer " + c);
         // update functions only when gearman-plugin is enabled
@@ -115,7 +115,7 @@ public class ComputerListenerImpl extends ComputerListener {
 
     @Override
     public void onTemporarilyOnline(Computer c) {
-        // fired when master or slave goes into temporary online state
+        // fired when built-in or slave goes into temporary online state
         logger.debug("---- " + ComputerListenerImpl.class.getName() + ":"
                 + " onTemporarilyOnline computer " + c);
         // update functions only when gearman-plugin is enabled

--- a/src/main/java/hudson/plugins/gearman/CustomGearmanFunctionFactory.java
+++ b/src/main/java/hudson/plugins/gearman/CustomGearmanFunctionFactory.java
@@ -40,7 +40,7 @@ public class CustomGearmanFunctionFactory extends DefaultGearmanFunctionFactory 
     private final GearmanProject project;
     private final Computer computer;
     private final String theClass;
-    private final String masterName;
+    private final String builtInName;
     private final MyGearmanWorkerImpl worker;
 
     private static final org.slf4j.Logger LOG =  LoggerFactory.getLogger(
@@ -48,31 +48,31 @@ public class CustomGearmanFunctionFactory extends DefaultGearmanFunctionFactory 
 
     public CustomGearmanFunctionFactory(String functionName, String className,
                                         GearmanProject project, Computer computer,
-                                        String masterName,
+                                        String builtInName,
                                         MyGearmanWorkerImpl worker) {
         super(functionName, className);
         this.theClass = className;
         this.project = project;
         this.computer = computer;
-        this.masterName = masterName;
+        this.builtInName = builtInName;
         this.worker = worker;
     }
 
 
     @Override
     public GearmanFunction getFunction() {
-        return createFunctionInstance(theClass, project, computer, masterName,
+        return createFunctionInstance(theClass, project, computer, builtInName,
                                       worker);
     }
 
-    private static GearmanFunction createFunctionInstance(String className, GearmanProject project, Computer computer, String masterName, MyGearmanWorkerImpl worker) {
+    private static GearmanFunction createFunctionInstance(String className, GearmanProject project, Computer computer, String builtInName, MyGearmanWorkerImpl worker) {
 
         GearmanFunction f = null;
         try {
 
             Class<?> c = Class.forName(className);
             Constructor<?> con = c.getConstructor(new Class[]{GearmanProject.class, Computer.class, String.class, MyGearmanWorkerImpl.class});
-            Object o = con.newInstance(new Object[] {project, computer, masterName, worker});
+            Object o = con.newInstance(new Object[] {project, computer, builtInName, worker});
 
             if (o instanceof GearmanFunction) {
                 f = (GearmanFunction) o;

--- a/src/main/java/hudson/plugins/gearman/ExecutorWorkerThread.java
+++ b/src/main/java/hudson/plugins/gearman/ExecutorWorkerThread.java
@@ -45,17 +45,17 @@ public class ExecutorWorkerThread extends AbstractWorkerThread{
             .getLogger(Constants.PLUGIN_LOGGER_NAME);
 
     private final Computer computer;
-    private final String masterName;
+    private final String builtInName;
 
     private HashMap<String,GearmanFunctionFactory> functionMap;
 
     // constructor
     public ExecutorWorkerThread(String host, int port, String name,
-                                Computer computer, String masterName,
+                                Computer computer, String builtInName,
                                 AvailabilityMonitor availability) {
         super(host, port, name, availability);
         this.computer = computer;
-        this.masterName = masterName;
+        this.builtInName = builtInName;
     }
 
     @Override
@@ -126,7 +126,7 @@ public class ExecutorWorkerThread extends AbstractWorkerThread{
                         String jobFunctionName = "build:" + projectName;
                         newFunctionMap.put(jobFunctionName, new CustomGearmanFunctionFactory(
                             jobFunctionName, StartJobWorker.class.getName(),
-                            project, computer, this.masterName, worker));
+                            project, computer, this.builtInName, worker));
                     }
                 } else { // register "build:$projectName:$label" if this
                          // node matches a node from the project label
@@ -145,7 +145,7 @@ public class ExecutorWorkerThread extends AbstractWorkerThread{
                         // register without label (i.e. "build:$projectName")
                         newFunctionMap.put(jobFunctionName, new CustomGearmanFunctionFactory(
                                 jobFunctionName, StartJobWorker.class.getName(),
-                                project, computer, this.masterName, worker));
+                                project, computer, this.builtInName, worker));
                         // iterate over the intersection of project and node labels
                         for (LabelAtom labelAtom : nodeProjectLabelAtoms) {
                             jobFunctionName = "build:" + projectName
@@ -153,7 +153,7 @@ public class ExecutorWorkerThread extends AbstractWorkerThread{
                             // register with label (i.e. "build:$projectName:$label")
                             newFunctionMap.put(jobFunctionName, new CustomGearmanFunctionFactory(
                                     jobFunctionName, StartJobWorker.class.getName(),
-                                    project, computer, this.masterName, worker));
+                                    project, computer, this.builtInName, worker));
                         }
                     }
                 }

--- a/src/main/java/hudson/plugins/gearman/GearmanPluginUtil.java
+++ b/src/main/java/hudson/plugins/gearman/GearmanPluginUtil.java
@@ -42,21 +42,21 @@ public class GearmanPluginUtil {
             .getLogger(Constants.PLUGIN_LOGGER_NAME);
 
     /*
-     * This method returns the real computer name.  Master computer
-     * by default has an empty string for the name.  But you
-     * need to use "master" to tell jenkins to do stuff,
-     * namely like schedule a build.
+     * This method returns the real computer name.
+	 * Built-in node * by default has an empty string for the name.  But you
+     * need to use "built-in" to tell jenkins to do stuff, namely like schedule a build.
      *
      * @param Computer
      *      The computer to lookup
      *
      * @return
-     *      "master" for the master computer or assigned name of the slave computer
+	 *      "built-in" for the built-in computer running on the controller or
+	 *      assigned name of the slave computer
      */
     public static String getRealName(Computer computer) {
 
         if (Jenkins.getInstance().getComputer("") == computer) {
-            return "master";
+            return "built-in";
         } else {
             return computer.getName();
         }

--- a/src/main/java/hudson/plugins/gearman/ManagementWorkerThread.java
+++ b/src/main/java/hudson/plugins/gearman/ManagementWorkerThread.java
@@ -39,11 +39,11 @@ public class ManagementWorkerThread extends AbstractWorkerThread{
             .getLogger(Constants.PLUGIN_LOGGER_NAME);
 
     private boolean registered = false;
-    private final String masterName;
+    private final String builtInName;
 
-    public ManagementWorkerThread(String host, int port, String name, String masterName, AvailabilityMonitor availability){
+    public ManagementWorkerThread(String host, int port, String name, String builtInName, AvailabilityMonitor availability){
         super(host, port, name, availability);
-        this.masterName = masterName;
+        this.builtInName = builtInName;
     }
 
     /**
@@ -63,9 +63,9 @@ public class ManagementWorkerThread extends AbstractWorkerThread{
         if (!registered) {
             Set<GearmanFunctionFactory> functionSet = new HashSet<GearmanFunctionFactory>();
 
-            functionSet.add(new DefaultGearmanFunctionFactory("stop:"+masterName,
+            functionSet.add(new DefaultGearmanFunctionFactory("stop:"+builtInName,
                             StopJobWorker.class.getName()));
-            functionSet.add(new DefaultGearmanFunctionFactory("set_description:"+masterName,
+            functionSet.add(new DefaultGearmanFunctionFactory("set_description:"+builtInName,
                     SetDescriptionWorker.class.getName()));
 
             updateJobs(functionSet);

--- a/src/main/java/hudson/plugins/gearman/SaveableListenerImpl.java
+++ b/src/main/java/hudson/plugins/gearman/SaveableListenerImpl.java
@@ -20,9 +20,12 @@ package hudson.plugins.gearman;
 
 import hudson.Extension;
 import hudson.XmlFile;
+import hudson.init.InitMilestone;
 import hudson.model.Saveable;
 import hudson.model.AbstractProject;
 import hudson.model.listeners.SaveableListener;
+
+import jenkins.model.Jenkins;
 
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.slf4j.Logger;
@@ -45,6 +48,10 @@ public class SaveableListenerImpl extends SaveableListener {
     // for just about any change that happens in Jenkins. This event
     // also doesn't provide much detail on what has changed.
     public void onChange(Saveable o, XmlFile file) {
+        if (Jenkins.get().getInitLevel() != InitMilestone.COMPLETED) {
+            logger.info("Plugins not fully loaded, ignoring change to " + file);
+            return;
+        }
         // update functions only when gearman-plugin is enabled
         if (!GearmanPluginConfig.get().isEnablePlugin()) {
             return;

--- a/src/main/java/hudson/plugins/gearman/StartJobWorker.java
+++ b/src/main/java/hudson/plugins/gearman/StartJobWorker.java
@@ -60,14 +60,14 @@ public class StartJobWorker extends AbstractGearmanFunction {
 
     Computer computer;
     GearmanProject project;
-    String masterName;
+    String builtInName;
     MyGearmanWorkerImpl worker;
 
-    public StartJobWorker(GearmanProject project, Computer computer, String masterName,
+    public StartJobWorker(GearmanProject project, Computer computer, String builtInName,
                           MyGearmanWorkerImpl worker) {
         this.project = project;
         this.computer = computer;
-        this.masterName = masterName;
+        this.builtInName = builtInName;
         this.worker = worker;
     }
 
@@ -76,7 +76,7 @@ public class StartJobWorker extends AbstractGearmanFunction {
 
        data.put("name", project.getJob().getName());
        data.put("number", build.getNumber());
-       data.put("manager", masterName);
+       data.put("manager", builtInName);
        data.put("worker", this.worker.getWorkerID());
 
        String rootUrl = Jenkins.getInstance().getRootUrl();

--- a/src/main/resources/index.jelly
+++ b/src/main/resources/index.jelly
@@ -1,4 +1,4 @@
 <?jelly escape-by-default='true'?>
 <div>
-  This plugin uses Gearman to support multiple Jenkins masters.
+  This plugin uses Gearman to support multiple Jenkins controllers.
 </div>

--- a/src/test/java/hudson/plugins/gearman/ExecutorWorkerThreadTest.java
+++ b/src/test/java/hudson/plugins/gearman/ExecutorWorkerThreadTest.java
@@ -80,7 +80,7 @@ public class ExecutorWorkerThreadTest{
         Project<?, ?> lemon = j.createFreeStyleProject("lemon");
         lemon.setAssignedLabel(new LabelAtom("linux"));
 
-        AbstractWorkerThread oneiric = new ExecutorWorkerThread("GearmanServer", 4730, "MyWorker", slave.toComputer(), "master", new NoopAvailabilityMonitor());
+        AbstractWorkerThread oneiric = new ExecutorWorkerThread("GearmanServer", 4730, "MyWorker", slave.toComputer(), "built-in", new NoopAvailabilityMonitor());
         oneiric.testInitWorker();
         oneiric.registerJobs();
         Set<String> functions = oneiric.worker.getRegisteredFunctions();
@@ -101,7 +101,7 @@ public class ExecutorWorkerThreadTest{
         Project<?, ?> lemon = j.createFreeStyleProject("lemon");
         lemon.setAssignedLabel(new LabelAtom("bogus"));
 
-        AbstractWorkerThread oneiric = new ExecutorWorkerThread("GearmanServer", 4730, "MyWorker", slave.toComputer(), "master", new NoopAvailabilityMonitor());
+        AbstractWorkerThread oneiric = new ExecutorWorkerThread("GearmanServer", 4730, "MyWorker", slave.toComputer(), "built-in", new NoopAvailabilityMonitor());
         oneiric.testInitWorker();
         oneiric.registerJobs();
         Set<String> functions = oneiric.worker.getRegisteredFunctions();
@@ -125,7 +125,7 @@ public class ExecutorWorkerThreadTest{
                                             4730,
                                             "MyWorker",
                                             slave.toComputer(),
-                                            "master",
+                                            "built-in",
                                             new NoopAvailabilityMonitor());
         oneiric.testInitWorker();
         oneiric.registerJobs();
@@ -152,7 +152,7 @@ public class ExecutorWorkerThreadTest{
                                             4730,
                                             "MyWorker",
                                             exclusive_slave.toComputer(),
-                                            "master",
+                                            "built-in",
                                             new NoopAvailabilityMonitor());
         oneiric.testInitWorker();
         oneiric.registerJobs();
@@ -172,7 +172,7 @@ public class ExecutorWorkerThreadTest{
         lemon.setAssignedLabel(new LabelAtom("linux"));
         lemon.disable();
 
-        AbstractWorkerThread oneiric = new ExecutorWorkerThread("GearmanServer", 4730, "MyWorker", slave.toComputer(), "master", new NoopAvailabilityMonitor());
+        AbstractWorkerThread oneiric = new ExecutorWorkerThread("GearmanServer", 4730, "MyWorker", slave.toComputer(), "built-in", new NoopAvailabilityMonitor());
         oneiric.testInitWorker();
         oneiric.registerJobs();
         Set<String> functions = oneiric.worker.getRegisteredFunctions();
@@ -194,7 +194,7 @@ public class ExecutorWorkerThreadTest{
         Project<?, ?> lemon = j.createFreeStyleProject("lemon");
         lemon.setAssignedLabel(new LabelAtom("linux"));
 
-        AbstractWorkerThread oneiric = new ExecutorWorkerThread("GearmanServer", 4730, "MyWorker", offlineSlave.toComputer(), "master", new NoopAvailabilityMonitor());
+        AbstractWorkerThread oneiric = new ExecutorWorkerThread("GearmanServer", 4730, "MyWorker", offlineSlave.toComputer(), "built-in", new NoopAvailabilityMonitor());
         oneiric.testInitWorker();
         oneiric.registerJobs();
         Set<String> functions = oneiric.worker.getRegisteredFunctions();
@@ -213,7 +213,7 @@ public class ExecutorWorkerThreadTest{
         MavenModuleSet lemon = j.createProject(MavenModuleSet.class, "lemon");
         lemon.setAssignedLabel(new LabelAtom("linux"));
 
-        AbstractWorkerThread oneiric = new ExecutorWorkerThread("GearmanServer", 4730, "MyWorker", slave.toComputer(), "master", new NoopAvailabilityMonitor());
+        AbstractWorkerThread oneiric = new ExecutorWorkerThread("GearmanServer", 4730, "MyWorker", slave.toComputer(), "built-in", new NoopAvailabilityMonitor());
         oneiric.testInitWorker();
         oneiric.registerJobs();
         Set<String> functions = oneiric.worker.getRegisteredFunctions();
@@ -235,7 +235,7 @@ public class ExecutorWorkerThreadTest{
         Project<?, ?> lemon = j.createFreeStyleProject("lemon");
         lemon.setAssignedLabel(new LabelAtom("!linux"));
 
-        AbstractWorkerThread oneiric = new ExecutorWorkerThread("GearmanServer", 4730, "MyWorker", slave.toComputer(), "master", new NoopAvailabilityMonitor());
+        AbstractWorkerThread oneiric = new ExecutorWorkerThread("GearmanServer", 4730, "MyWorker", slave.toComputer(), "built-in", new NoopAvailabilityMonitor());
         oneiric.testInitWorker();
         oneiric.registerJobs();
         Set<String> functions = oneiric.worker.getRegisteredFunctions();
@@ -245,22 +245,22 @@ public class ExecutorWorkerThreadTest{
 
     /*
      * This test verifies that gearman functions are correctly registered for a
-     * workflow project. All workflow projects have are executed on master itself,
-     * so they have default assigned labels "master", {@link WorkflowJob#getAssignedLabel}
+     * workflow project. All workflow projects have to be executed on the built-in node itself,
+     * so they have default assigned label "built-in", {@link WorkflowJob#getAssignedLabel}
      */
     @Test
     public void testRegisterJobs_WorkflowProject() throws Exception {
 
         WorkflowJob lemon = j.createProject(WorkflowJob.class,"lemon");
 
-        AbstractWorkerThread oneiric = new ExecutorWorkerThread("GearmanServer", 4730, "MyWorker", j.jenkins.getComputer(""), "master", new NoopAvailabilityMonitor());
+        AbstractWorkerThread oneiric = new ExecutorWorkerThread("GearmanServer", 4730, "MyWorker", j.jenkins.getComputer(""), "built-in", new NoopAvailabilityMonitor());
         oneiric.testInitWorker();
         oneiric.registerJobs();
         Set<String> functions = oneiric.worker.getRegisteredFunctions();
 
         assertEquals(2, functions.size());
         assertTrue(functions.contains("build:lemon"));
-        assertTrue(functions.contains("build:lemon:master"));
+        assertTrue(functions.contains("build:lemon:built-in"));
     }
 
 

--- a/src/test/java/hudson/plugins/gearman/GearmanPluginUtilTest.java
+++ b/src/test/java/hudson/plugins/gearman/GearmanPluginUtilTest.java
@@ -55,9 +55,9 @@ public class GearmanPluginUtilTest {
     }
 
     @Test
-    public void testGetRealNameMaster() throws Exception {
+    public void testGetRealNameBuiltIn() throws Exception {
 
-        assertEquals("master", GearmanPluginUtil.getRealName(Jenkins.getInstance().getComputer("")));
+        assertEquals("built-in", GearmanPluginUtil.getRealName(Jenkins.getInstance().getComputer("")));
     }
 
     @Test

--- a/src/test/java/hudson/plugins/gearman/GearmanProxyTest.java
+++ b/src/test/java/hudson/plugins/gearman/GearmanProxyTest.java
@@ -56,7 +56,7 @@ public class GearmanProxyTest {
 
         gp.createManagementWorker();
 
-        // mgmt: 1 master
+        // mgmt: 1 built-in
         assertEquals(1, gp.getNumExecutors());
         //        assertTrue(gp.getGmwtHandles().get(0).isAlive());
     }
@@ -70,7 +70,7 @@ public class GearmanProxyTest {
 
         gp.createExecutorWorkersOnNode(slave.toComputer());
 
-        // exec: 1 master
+        // exec: 1 built-in
         assertEquals(1, gp.getNumExecutors());
     }
 
@@ -79,7 +79,7 @@ public class GearmanProxyTest {
 
         gp.initWorkers();
 
-        // exec: 1 slave, 1 master + mgmnt: 1
+        // exec: 1 slave, 1 built-in + mgmnt: 1
         assertEquals(3, gp.getNumExecutors());
     }
 
@@ -89,7 +89,7 @@ public class GearmanProxyTest {
         DumbSlave slave = j.createSlave();
         gp.initWorkers();
 
-        // exec: 2 slaves, 1 master + mgmnt: 1
+        // exec: 2 slaves, 1 built-in + mgmnt: 1
         assertEquals(4, gp.getNumExecutors());
     }
 }

--- a/src/test/java/hudson/plugins/gearman/ManagementWorkerThreadTest.java
+++ b/src/test/java/hudson/plugins/gearman/ManagementWorkerThreadTest.java
@@ -58,19 +58,19 @@ public class ManagementWorkerThreadTest {
     @Test
     public void testRegisterJobs() {
         AbstractWorkerThread manager = new ManagementWorkerThread("GearmanServer", 4730,
-                                                                  "master_manager", "master", new NoopAvailabilityMonitor());
+                                                                  "built-in_manager", "built-in", new NoopAvailabilityMonitor());
         manager.testInitWorker();
         manager.registerJobs();
         Set<String> functions = manager.worker.getRegisteredFunctions();
-        assertTrue(functions.contains("set_description:master"));
-        assertTrue(functions.contains("stop:master"));
+        assertTrue(functions.contains("set_description:built-in"));
+        assertTrue(functions.contains("stop:built-in"));
     }
 
     @Test
     public void testManagerId() {
         AbstractWorkerThread manager = new ManagementWorkerThread("GearmanServer", 4730,
-                                                                  "master_manager", "master", new NoopAvailabilityMonitor());
-        assertEquals("master_manager", manager.getName());
+                                                                  "built-in_manager", "built-in", new NoopAvailabilityMonitor());
+        assertEquals("built-in_manager", manager.getName());
     }
 
 }

--- a/src/test/java/hudson/plugins/gearman/StartJobWorkerTest.java
+++ b/src/test/java/hudson/plugins/gearman/StartJobWorkerTest.java
@@ -38,14 +38,14 @@ public class StartJobWorkerTest {
         doNothing().when(listener).handleGearmanIOEvent(any());
 
         // setup available computers
-        Computer masterNode = j.jenkins.getComputer("");
-        GearmanProxy.getInstance().createExecutorWorkersOnNode(masterNode);
+        Computer builtInNode = j.jenkins.getComputer("");
+        GearmanProxy.getInstance().createExecutorWorkersOnNode(builtInNode);
 
         // setup worker
         StartJobWorker startJobWorker = new StartJobWorker(
                 gearmanProject, // zuul project
-                masterNode, // computer - master node
-                masterNode.getHostName(),
+                builtInNode, // computer - built-in node
+                builtInNode.getHostName(),
                 myGearmanWorker
         );
         startJobWorker.registerEventListener(listener);


### PR DESCRIPTION
Address a SaveableListener related issue JENKINS-54888

Take in account `master` being renamed to `built-in` node https://github.com/jenkinsci/jenkins/pull/5425

Require Jenkins 2.139.1 and update dependencies.